### PR TITLE
v0.3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 with open("README.md", "r", encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 setup(
     name='pageo',


### PR DESCRIPTION
* Добавлен аргумент `is_open_page` в класс BasePage. 
`is_open_page` - булев тип, указывающий на необходимость открыть страницу сразу после создания объекта. По умолчанию `True`.
* Обновлена документация.